### PR TITLE
Enforce a jj repo check.

### DIFF
--- a/spaceship-jj.plugin.zsh
+++ b/spaceship-jj.plugin.zsh
@@ -40,6 +40,9 @@ spaceship_jj() {
   # Check if jj command is available for execution
   spaceship::exists jj || return
 
+  # Check if the current directory contains a jj project
+  jj root --quiet >/dev/null 2>&1 || return
+
   # Refresh parts of the jj section
   for subsection in "${SPACESHIP_JJ_ORDER[@]}"; do
     spaceship::core::refresh_section --sync "$subsection"

--- a/tests/spaceship-jj-plugin.test.zsh
+++ b/tests/spaceship-jj-plugin.test.zsh
@@ -1,0 +1,61 @@
+#!/usr/bin/env zsh
+
+# Required for shunit2 to run correctly
+CWD="${${(%):-%x}:A:h}"
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+# Use system Spaceship or fallback to Spaceship Docker on CI
+typeset -g SPACESHIP_ROOT="${SPACESHIP_ROOT:=/spaceship}"
+
+# ------------------------------------------------------------------------------
+# SHUNIT2 HOOKS
+# ------------------------------------------------------------------------------
+
+setUp() {
+  # Enter the test directory
+  cd $SHUNIT_TMPDIR
+}
+
+oneTimeSetUp() {
+  export TERM="xterm-256color"
+
+  source "$SPACESHIP_ROOT/spaceship.zsh" > /dev/null 2>&1
+  source "$(dirname $CWD)/spaceship-jj.plugin.zsh"
+
+  SPACESHIP_PROMPT_ASYNC=false
+  SPACESHIP_PROMPT_FIRST_PREFIX_SHOW=true
+  SPACESHIP_PROMPT_ADD_NEWLINE=false
+  SPACESHIP_PROMPT_ORDER=(jj)
+
+  echo "Spaceship version: $(spaceship --version)"
+}
+
+oneTimeTearDown() {
+  unset SPACESHIP_PROMPT_ASYNC
+  unset SPACESHIP_PROMPT_FIRST_PREFIX_SHOW
+  unset SPACESHIP_PROMPT_ADD_NEWLINE
+  unset SPACESHIP_PROMPT_ORDER
+}
+
+# ------------------------------------------------------------------------------
+# TEST CASES
+# ------------------------------------------------------------------------------
+
+test_spaceship_jj_no_jj_root() {
+  local actual="$(spaceship::testkit::render_prompt)"
+  local expanded="$(print -P -- "$actual")"
+  local raw_section_text="$(printf '%s' "$expanded" | sed -E $'s/\x1b\\[[0-9;]*[[:alpha:]]//g')"
+
+  local pattern='^$'
+
+  [[ "$raw_section_text" =~ "$pattern" ]] \
+    || fail "render in jj dir missing expected content: <$raw_section_text>"
+}
+
+# ------------------------------------------------------------------------------
+# SHUNIT2
+# Run tests with shunit2
+# ------------------------------------------------------------------------------
+
+source "$SPACESHIP_ROOT/tests/shunit2/shunit2"

--- a/tests/spaceship-jj.tests.zsh
+++ b/tests/spaceship-jj.tests.zsh
@@ -23,8 +23,10 @@ run_test_file() {
   return $exit_code
 }
 
-run_test_file "spaceship-jj Description" $CWD/spaceship-jj-desc.test.zsh
+run_test_file "spaceship-jj Core Plugin tests" $CWD/spaceship-jj-plugin.test.zsh
 
-run_test_file "spaceship-jj Commit" $CWD/spaceship-jj-commit.test.zsh
+run_test_file "spaceship-jj Description tests" $CWD/spaceship-jj-desc.test.zsh
 
-run_test_file "spaceship-jj Status" $CWD/spaceship-jj-status.test.zsh
+run_test_file "spaceship-jj Commit tests" $CWD/spaceship-jj-commit.test.zsh
+
+run_test_file "spaceship-jj Status tests" $CWD/spaceship-jj-status.test.zsh


### PR DESCRIPTION
Prevent the spaceship-jj section from appearing in every directory by checking for a jj root project.
